### PR TITLE
Feature/new auto bump mode parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v9 - 07/13/2023
+
+- New parameter (`auto-version-bump-mode`) to set a mode different then `auto` for auto-bump, so on auto bump we can select which mode we want(major, minor, patch) without add it into the PR Comment
+- For the maven bump, added configuration to update subModules as well.
+- For the maven bump, change to git add all the pom.xml files from the project.
+
 ## v7 - 12/28/2022
 
 - Deprecating save-state and set-output commands

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ jobs:
 * `auto-version-bump-suffix`: Version suffix for auto bump
 * `auto-version-bump-higher`: Should after the suffix a number bumped?
 * `auto-version-bump-release`: Should on a automatic bump a tag and release created?
+* `auto-version-bump-mode`: Mode for auto version, could be major, minor, patch or auto. Default is auto.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: 'Should on a automatic bump a tag and release created?'
     required: true
     default: false
+  auto-version-bump-mode:
+    description: 'Mode for auto version, could be major, minor, patch or auto. Default is auto.'
+    required: true
+    default: auto
 
 outputs:
   version:
@@ -81,6 +85,7 @@ runs:
         AUTO_SUFFIX: ${{ inputs.auto-version-bump-suffix }}
         AUTO_HIGHER: ${{ inputs.auto-version-bump-higher }}
         AUTO_RELEASE: ${{ inputs.auto-version-bump-release }}
+        AUTO_MODE: ${{ inputs.auto-version-bump-mode }}
       run: ${{github.action_path}}/src/version-bump.sh
       shell: bash
 

--- a/src/version-bump.sh
+++ b/src/version-bump.sh
@@ -72,7 +72,7 @@ fi
 
 if [ -f ./pom.xml ]; then
     REPO_SYSTEM=MAVEN
-    BUILD_FILE=./pom.xml
+    BUILD_FILE=`find . -name 'pom.xml'`
 else
     REPO_SYSTEM=GRADLE
     if [ -f gradle.properties ] && grep -E -q "version=${CURRENT_VERSION}" gradle.properties; then

--- a/src/version-bump.sh
+++ b/src/version-bump.sh
@@ -67,7 +67,7 @@ elif git log -1 | grep -q "#minor"; then
 elif git log -1 | grep -q "#patch"; then
     BUMP_MODE="patch"
 elif [[ "${AUTO}" == "true" ]]; then
-    BUMP_MODE="auto"
+    BUMP_MODE="${AUTO_MODE}"
 fi
 
 if [ -f ./pom.xml ]; then
@@ -93,7 +93,7 @@ else
     echo "version will be bumped from" $OLD_VERSION "to" $NEW_VERSION
     REPO="https://$GITHUB_ACTOR:$TOKEN@github.com/$GITHUB_REPOSITORY.git"
     if [ "${REPO_SYSTEM}" = "MAVEN" ]; then
-        mvn -q versions:set -DnewVersion="${NEW_VERSION}"
+        mvn -q versions:set -DnewVersion="${NEW_VERSION}" -DprocessAllModules=true
     elif [ "${REPO_SYSTEM}" = "GRADLE" ]; then
         sed -i "s/\(version *= *['\"]*\)${OLD_VERSION}\(['\"]*\)/\1${NEW_VERSION}\2/" ${BUILD_FILE}
     fi


### PR DESCRIPTION
Changes proposed in this merge request:
- Additions: New parameter (`auto-version-bump-mode`) to set a mode different then `auto` for auto-bump, so on auto bump we can select which mode we want(major, minor, patch) without add it into the PR Comment.
- Updates: For the maven bump, added configuration to update subModules as well. For the maven bump, change to git add all the pom.xml files from the project.
- Deletions:

### Pre-merge Checklist
- [X] Write + run tests
- [X] Update documentation
- [X] Update CHANGELOG and increment version
